### PR TITLE
add attr_accessible for preferences

### DIFF
--- a/app/models/spree/calculator/flat_percent_taxon_total.rb
+++ b/app/models/spree/calculator/flat_percent_taxon_total.rb
@@ -2,6 +2,8 @@ module Spree
   class Calculator::FlatPercentTaxonTotal < Calculator
     preference :flat_percent, :decimal, :default => 0
     preference :taxon, :string, :default => ''
+    
+    attr_accessible :preferred_flat_percent, :preferred_taxon
 
     def self.description
       I18n.t(:flat_percent_taxon)


### PR DESCRIPTION
The calculator is missing attr_accessible for the preferences causing it to not work in recent versions of spree.
